### PR TITLE
Docker compose refactor

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgresql://postgres:changeit@localhost:5432/postgres
+DATABASE_URL=postgresql://postgres:changeit@localhost:5432/postgres-db

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Cargo.lock
 !diesel_cli/Cargo.lock
 *.env
 *.snap.new
+
+# MAC OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ check and see if the docker daemon is running
 
 build and start the postgres db docker container
 
-`sudo docker run --name postgres-db -p 5432:5432 -e POSTGRES_PASSWORD=changeit -d postgres-db`
+`docker compose up`
 
 use diesel to run the migration which will add the greeting to the first row of the db.
 

--- a/diesel.toml
+++ b/diesel.toml
@@ -7,4 +7,4 @@ custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
 
 [migrations_directory]
 # Add your path below so diesel can find your migrations directory
-dir = "add your path here..../tokio_postgres/migrations"
+dir = "./migrations"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  db:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: changeit
+      POSTGRES_DB: postgres-db
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
A few little things split across micro-commits.

- Replace Dockerfile with Docker Compose: I find this better if you aren't changing the image, this also allows adding things like Elastic or Redis easier if needed in the future

- Version lock postgres to 16 - latest in docker can cause some weird bugs when 17 comes out

- Update diesel.toml to use relative instead of absolute pathing - should now work on any machine that is running from root.

- Updated README to use docker compose

- Ignore MacOS .DS_Store files in Gitignore

Future ideas:
Add [Just](https://github.com/casey/just) to make these commands for setup and running in dev easier. "Just setup"